### PR TITLE
[feat] 캐릭터의 방어

### DIFF
--- a/bin/domain/usecase/character.dart
+++ b/bin/domain/usecase/character.dart
@@ -22,7 +22,11 @@ class Character {
     monster.health -= attack;
   }
 
-  void defend() {}
+  void defend(Monster monster) {
+    int heal = (monster.attack / 10).toInt();
+    print('$name이(가) 방어 태세를 취하여 $heal만큼 체력을 얻었습니다.');
+    health += heal;
+  }
 
   void showStatus() {
     print('$name - 체력: $health, 공격력: $attack, 방어력: $defense');


### PR DESCRIPTION
### 🚀 개요
캐릭터가 방어할 때 몬스터가 입힌 공격력의 10%만큼 캐릭터의 체력을 상승한다.

### 🔧 변경사항
- defend 메서드 구현
- 매개변수로 받은 monster 공격력의 10%만큼 체력을 상승한다.

### 💡issue : #8 