### PR TITLE
[bug] 몬스터의 공격력을 랜덤으로 지정 

### DIFF
--- a/bin/domain/usecase/monster.dart
+++ b/bin/domain/usecase/monster.dart
@@ -22,7 +22,8 @@ class Monster {
   void attackCharacter(Character character) {
     print('$name이(가) ${character.name}에게 $attack의 데미지를 입혔습니다.');
     character.health -= attack - character.defense;
-    attack = Random().nextInt(attack - character.defense) + character.defense;
+    attack =
+        Random().nextInt(maxAttack - character.defense) + character.defense;
   }
 
   void showStatus() {


### PR DESCRIPTION
### 🚀 개요
몬스터는 캐릭터 공격 후, 공격력을 랜덤값으로 변경한다.
이 과정에서 몬스터의 공격력이 0이 되어버리는 상황이 발생했다.

### 🔧 변경사항
- 몬스터의 최대 공격력을 저장하는 maxAttack을 추가
- maxAttack을 기준으로 공격력 랜덤값 변경

### 💡issue : #28 