### PR TITLE
[bug] 캐릭터나 몬스터의 체력이 0이 되어도 전투가 종료되지 않는 상황

### DIFF
--- a/bin/domain/usecase/game.dart
+++ b/bin/domain/usecase/game.dart
@@ -118,8 +118,8 @@ class Game {
       // 모든 턴이 끝난 후 1초 대기
       await Future.delayed(Duration(milliseconds: 1000));
 
-      // 캐릭터의 체력이 0 미만이면, 전투 종료
-      if (character.health < 0) {
+      // 캐릭터의 체력이 0 이하면, 전투 종료
+      if (character.health <= 0) {
         return false;
       }
     }


### PR DESCRIPTION
### 🚀 개요
전투 종료 조건 중 캐릭터나 몬스터의 체력이 0이어도 전투가 종료되지 않는 상황을 0이하로 수정했다.

### 🔧 변경사항
- 전투 종료 조건 중 캐릭터의 체력을 0미만에서 0이하로 수정
- 전투 종료 조건 중 몬스터의 체력을 0미만에서 0이하로 수정

### 💡issue : #31 