### PR TITLE
[bug] 몬스터 리스트의 공격력 표시 제거

### DIFF
--- a/bin/utils/load_monster.dart
+++ b/bin/utils/load_monster.dart
@@ -9,7 +9,6 @@ List<Monster> loadMonsterStatsAsync() {
     List<Monster> monsterList = [];
     for (int i = 0; i < lines.length; i++) {
       monsterList.add(Monster.fromPlainText(lines[i]));
-      print(monsterList[i].attack);
     }
     return monsterList;
   } on PathNotFoundException {


### PR DESCRIPTION
### 🚀 개요
몬스터 객체를 생성할 때 몬스터의 공격이 출력되는 코드를 제거했다.

### 🔧 변경사항
- 공격력이 출력되는 코드 제거

### 💡issue : #41 